### PR TITLE
Make buttons visible in Bootstrap theme

### DIFF
--- a/templates/CRM/Materialbestellung/Form/Material.tpl
+++ b/templates/CRM/Materialbestellung/Form/Material.tpl
@@ -17,7 +17,7 @@
   {/foreach}
 
   {* FOOTER *}
-  <div class="crm-submit-buttons">
+  <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix">
   {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
 </div>


### PR DESCRIPTION
For some reason the buttons for submitting the material form do not show up in the new theme. I changed the div class from `crm-submit-buttons` to `ui-dialog-buttonpane ui-widget-content ui-helper-clearfix` to fix this.